### PR TITLE
Change 'var' for 'let' in 'PowerWall.astro'

### DIFF
--- a/src/components/PowerWall.astro
+++ b/src/components/PowerWall.astro
@@ -44,7 +44,7 @@ import Section from "./Section.astro";
     }
   }
 
-  var imageElement = document.querySelector("#bg-image-powerwall") as HTMLImageElement;
+  let imageElement = document.querySelector("#bg-image-powerwall") as HTMLImageElement; // TypeScript
 
   if (isEdge()) {
     imageElement.src = "powerwall.webp";


### PR DESCRIPTION
JS buenas prácticas. 'let' es más seguro y recomendado que 'var. No afecta al comportamiento a menos que las variables declaradas sean izadas (hoisted) al principio de su ámbito. https://developer.mozilla.org/es/docs/Glossary/Hoisting