### PR TITLE
Change 'var' for 'let' in 'ModelX.astro'

### DIFF
--- a/src/components/ModelX.astro
+++ b/src/components/ModelX.astro
@@ -44,7 +44,7 @@ import Section from "./Section.astro";
     }
   }
 
-  var imageElement = document.querySelector("#bg-image-modelx") as HTMLImageElement;
+  let imageElement = document.querySelector("#bg-image-modelx") as HTMLImageElement; // TypeScript
 
   if (isEdge()) {
     imageElement.src = "model-x.webp";


### PR DESCRIPTION
JS buenas prácticas. 'let' es más seguro y recomendado que 'var. No afecta al comportamiento a menos que las variables declaradas sean izadas (hoisted) al principio de su ámbito. https://developer.mozilla.org/es/docs/Glossary/Hoisting