### PR TITLE
Change 'var' for 'let' in 'Accessories.astro'

### DIFF
--- a/src/components/Accessories.astro
+++ b/src/components/Accessories.astro
@@ -44,7 +44,7 @@ import Section from "./Section.astro";
     }
   }
 
-  var imageElement = document.querySelector("#bg-image-accessories") as HTMLImageElement;
+  let imageElement = document.querySelector("#bg-image-accessories") as HTMLImageElement; // TypeScript
 
   if (isEdge()) {
     imageElement.src = "accessories.webp";


### PR DESCRIPTION
JS buenas prácticas. 'let' es más seguro y recomendado que 'var. No afecta al comportamiento a menos que las variables declaradas sean izadas (hoisted) al principio de su ámbito.